### PR TITLE
support calling apigateway

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,12 @@ Sign.prototype._getQuery = function () {
  * @return {string}
  */
 Sign.prototype._getService = function () {
-  return url.parse(this.url).host.split('.', 2)[0];
+  var host = url.parse(this.url).host.split('.');
+  if(host[1] === 'execute-api') {
+    return host[1];
+  } else {
+    return host[0];
+  }
 };
 
 /**


### PR DESCRIPTION
I tried to call apigateway(example https://abc.execute-api.us-east-1.amazonaws.com/prod) using this library.
But it doesn't seem to be fine...

```
AWS4-HMAC-SHA256 Credential=xxxxxxxxx/20151003/us-east-1/abc/aws4_request, SignedHeaders=authorization;date;host, Signature=xxxxxxx
{"message":"Credential should be scoped to correct service: 'execute-api'. "}
```
- ApiGateway or other REST APIs URL->https://{aws_service}.{region}.amazonaws.com
- Invole ApiGateway URL->https://{restapi_id}.execute-api.{region}.amazonaws.com

I have changed it and confirm that it works for me.

```
AWS4-HMAC-SHA256 Credential=xxxxxxxxx/20151003/us-east-1/execute-api/aws4_request, SignedHeaders=authorization;date;host, Signature=xxxxxxx
{
 [
  {
   "id":1,
   "title":"RESTful Webサービス"
  },
  {
   "id":2,
   "title":"Web API: The Good Parts"
  },
  {
   "id":3,
   "title":"Restlet in Action"
  },
  ]
}
```

Could you check my pull request?

Thanks!
